### PR TITLE
fix: Fallback scene title

### DIFF
--- a/src/components/Title.tsx
+++ b/src/components/Title.tsx
@@ -1,9 +1,10 @@
-import { makeSceneUrl } from "../helpers";
-
+import { getFilename, makeSceneUrl } from "../helpers";
 const { React } = window.PluginApi;
 
 const Title: React.FC<TitleProps> = ({ scene }) => {
-  const title = scene.title ?? "Untitled";
+  // Title should be the given title > filename > "Untitled"
+  const filename = getFilename({ scene }) ?? "Untitled";
+  const title = scene.title || filename;
   const link = makeSceneUrl({ scene });
 
   return (

--- a/src/helpers/data.ts
+++ b/src/helpers/data.ts
@@ -1,0 +1,13 @@
+/** Get the filename of a scene */
+export const getFilename = ({ scene }: IgetFilename): string | undefined => {
+  const file = scene.files.length ? scene.files[0] : undefined;
+  if (!file) return undefined;
+
+  const pathArr = file.path.split("/");
+  return pathArr[pathArr.length - 1];
+};
+
+interface IgetFilename {
+  /** The scene data. */
+  scene: Scene;
+}

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,3 +1,4 @@
+export * from "./data";
 export * from "./icon";
 export * from "./link";
 export * from "./sort";


### PR DESCRIPTION
Fixed bug where no scene title is displayed if one hasn't been set. This will now fallback to the filename, same as the native experience, with a final fallback of "Untitled".